### PR TITLE
Custom boundaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,32 +2,35 @@ FROM python:3.10-bullseye AS apt
 LABEL maintainer="fraph24@gmail.com"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-WORKDIR /home/app
+WORKDIR /app
 
 FROM apt AS builder
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get -qy install npm
-WORKDIR /home/app/web
+WORKDIR /app/web
 COPY web/package.json web/package-lock.json ./
-RUN --mount=type=cache,target=/home/app/.npm npm ci
+RUN --mount=type=cache,target=/app/.npm npm ci
 COPY web/webpack.config.js ./
 COPY web/src ./src
 ARG SENTRY_DSN
 RUN npm run build
 
 FROM apt AS base
+ARG UID=1000
+ARG GID=1000
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get -qy install libyajl-dev && \
-    useradd --user-group --system --no-create-home --no-log-init app && \
+    groupadd -g ${GID} app && \
+    useradd -u ${UID} -g ${GID} --system --create-home --no-log-init app && \
     chown -R app:app .
 COPY --chown=app:app pyproject.toml pdm.lock ./
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip3 install pdm
 USER app
-RUN --mount=type=cache,target=/root/.cache/pdm \
+RUN --mount=type=cache,target=/app/.cache/pdm \
     pdm install --production --no-self
 
-COPY --from=builder --chown=app:app /home/app/web/dist/ web/dist/
+COPY --from=builder --chown=app:app /app/web/dist/ web/dist/
 COPY --chown=app:app web/dist/index.html web/dist/robots.txt web/dist/
 
 COPY --chown=app:app is-osm-uptodate.py ./
@@ -37,6 +40,6 @@ EXPOSE 8000/tcp
 
 ARG SENTRY_DSN
 ENV SENTRY_DSN=$SENTRY_DSN
-ENV PYTHONPATH=__pypackages__/3.10/lib
-ENV PATH=$PATH:__pypackages__/3.10/bin
+ENV PYTHONPATH=/app/__pypackages__/3.10/lib
+ENV PATH=$PATH:/app/__pypackages__/3.10/bin
 CMD ["gunicorn", "is-osm-uptodate:webapp", "--bind", "0.0.0.0:8000", "--workers", "2", "--worker-class", "aiohttp.GunicornWebWorker", "--timeout", "300"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ Page on OSM wiki: [wiki.openstreetmap.org/wiki/Is_OSM_up-to-date](https://wiki.o
 Open [is-osm-uptodate.frafra.eu](https://is-osm-uptodate.frafra.eu/) (or your local instance). Try to change the location and click on the refresh button in order to get the nodes for the new bounding box.
 Enable the experimental `Tiles` layer to load data grouped by tile.
 
+## Tiles and QGIS
+
+QGIS supports XYZ/TMS layers natively. Create a new `XYZ Tiles` connection using these parameters:
+
+- `https://is-osm-uptodate.frafra.eu/tiles/{z}/{x}/{y}.png?upscale=256`
+- `min_zoom_level`: 12
+- `max_zoom_level`: 17 (reccomended)
+
+The tiles URL can be also configured with additional parameters, such as:
+- `resolution`: each tile has `resolution x resolution` pixels (deafult: 8)
+- `filter`
+- `mode`, which can be set to:
+  - `creation`
+  - `lastedit` (default)
+  - `revisions`
+  - `frequency`
+- `scale_min`
+- `scale_max`
+
+Here is another example:
+```
+https://is-osm-uptodate.frafra.eu/tiles/{z}/{x}/{y}.png?upscale=256&filter=amenity=*&mode=revisions&scale_max=10
+```
+
 ## Command line
 
 Example:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ docker compose --profile prod down
 ## Develop
 
 ```bash
+docker compose --profile dev build \
+    --build-arg UID=$(id -u) --build-arg GID=$(id -g)
 docker compose --profile dev up
 docker compose --profile dev down
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Enable the experimental `Tiles` layer to load data grouped by tile.
 Example:
 
 ```
-$ curl 'http://is-osm-uptodate.frafra.eu/api/getData?minx=9.188295196&miny=45.4635324507&maxx=9.1926242813&maxy=45.4649771956' -o milan-duomo.json
+$ curl 'https://is-osm-uptodate.frafra.eu/api/getData?minx=9.188295196&miny=45.4635324507&maxx=9.1926242813&maxy=45.4649771956' -o milan-duomo.json
+$ curl -X POST -F geojson=@boundary.geojson 'https://is-osm-uptodate.frafra.eu/api/getStats' -o stats.json
 ```
 
 # Common issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       REDIS_HOST: redis-dev
       GUNICORN_CMD_ARGS: "--reload --log-level debug"
     volumes:
-      - ./server:/home/app/server:ro
-      - ./web:/home/app/web:ro
+      - ./server:/app/server:ro
+      - ./web:/app/web:ro
     ports:
       - 8000:8000
   app-test:
@@ -49,7 +49,7 @@ services:
     environment:
       BACKEND_URL: http://app-dev:8000
     volumes:
-      - ./web:/home/app/web
+      - ./web:/app/web
     ports:
       - 8080:8080
   redis:
@@ -74,4 +74,4 @@ services:
     environment:
       URL: "http://app-test:8000"
     volumes:
-      - ./latest_logs/:/home/app/latest_logs/
+      - ./latest_logs/:/app/latest_logs/

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -14,6 +14,14 @@ Install YAJI library:
 - Debian/Ubuntu users: `apt-get install libyajl-dev`
 - Fedora users: `dnf install yajl-devel`
 
+## GEOS
+
+Shapely requires `geos_c.h`, which is provided by `geos-devel` in Fedora.
+
+## Additional Python dependencies
+
+Python headers could be needed, whic are provided by `python-devel` in Fedora.
+
 ## PDM
 
 [PDM](https://pdm.fming.dev/) is a Python package manager, that can be installed using `pip` or `pipx`:

--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ kill_timeout = 5
   SENTRY_DSN = "https://272ecef41e6748cc8b2e955f3a23d67a@o1253953.ingest.sentry.io/6421667"
 
 [[statics]]
-  guest_path = "/home/app/web/dist/"
+  guest_path = "/app/web/dist/"
   url_prefix = "/"
 
 [[services]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -357,7 +357,7 @@ summary = "Tiny 'shelve'-like database with concurrency support"
 [[package]]
 name = "pillow"
 version = "8.4.0"
-requires_python = ">=3.6"
+requires_python = ">=3.7"
 summary = "Python Imaging Library (Fork)"
 
 [[package]]
@@ -663,6 +663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shapely"
+version = "1.8.2"
+requires_python = ">=3.6"
+summary = "Geometric objects, predicates, and operations"
+
+[[package]]
 name = "simplejson"
 version = "3.17.6"
 requires_python = ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*"
@@ -770,7 +776,7 @@ dependencies = [
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:88f9bdb36434dfbeea4b2a5b5e350bf20ccd9f46898b6972ff60cd7675ecc6fa"
+content_hash = "sha256:44d0c7f46bd297ba2b244347afff9f9c2e696c35ecacc9ca43ef19a94fb5b363"
 
 [metadata.files]
 "aiohttp 3.8.1" = [
@@ -1501,6 +1507,42 @@ content_hash = "sha256:88f9bdb36434dfbeea4b2a5b5e350bf20ccd9f46898b6972ff60cd767
 "setuptools-scm 6.4.2" = [
     {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
     {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
+]
+"shapely 1.8.2" = [
+    {file = "Shapely-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c9e3400b716c51ba43eea1678c28272580114e009b6c78cdd00c44df3e325fa"},
+    {file = "Shapely-1.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce0b5c5f7acbccf98b3460eecaa40e9b18272b2a734f74fcddf1d7696e047e95"},
+    {file = "Shapely-1.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3a40bf497b57a6625b83996aed10ce2233bca0e5471b8af771b186d681433ac5"},
+    {file = "Shapely-1.8.2-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6bdc7728f1e5df430d8c588661f79f1eed4a2728c8b689e12707cfec217f68f8"},
+    {file = "Shapely-1.8.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a60861b5ca2c488ebcdc706eca94d325c26d1567921c74acc83df5e6913590c7"},
+    {file = "Shapely-1.8.2-cp310-cp310-win32.whl", hash = "sha256:840be3f27a1152851c54b968f2e12d718c9f13b7acd51c482e58a70f60f29e31"},
+    {file = "Shapely-1.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:c60f3758212ec480675b820b13035dda8af8f7cc560d2cc67999b2717fb8faef"},
+    {file = "Shapely-1.8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:56413f7d32c70b63f239eb0865b24c0c61029e38757de456cc4ab3c416559a0b"},
+    {file = "Shapely-1.8.2-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:256bdf8080bb7bb504d47b2c76919ecebab9708cc1b26266b3ec32b42448f642"},
+    {file = "Shapely-1.8.2-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c0a0d7752b145343838bd36ed09382d85f5befe426832d7384c5b051c147acbd"},
+    {file = "Shapely-1.8.2-cp36-cp36m-win32.whl", hash = "sha256:62056e64b12b6d483d79f8e34bf058d2fe734d51c9227c1713705399434eff3b"},
+    {file = "Shapely-1.8.2-cp36-cp36m-win_amd64.whl", hash = "sha256:8e3ed52a081da58eb4a885c157c594876633dbd4eb283f13ba5bf39c82322d76"},
+    {file = "Shapely-1.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7c8eda45085ccdd7f9805ea4a93fdd5eb0b6039a61d5f0cefb960487e6dc17a1"},
+    {file = "Shapely-1.8.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:beee3949ddf381735049cfa6532fb234d5d20a5be910c4f2fb7c7295fd7960e3"},
+    {file = "Shapely-1.8.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e07b0bd2a0e61a8afd4d1c1bd23f3550b711f01274ffb53de99358fd781eefd8"},
+    {file = "Shapely-1.8.2-cp37-cp37m-win32.whl", hash = "sha256:78966332a89813b237de357a03f612fd451a871fe6e26c12b6b71645fe8eee39"},
+    {file = "Shapely-1.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8fe641f1f61b3d43dd61b5a85d2ef023e6e19bf8f204a5160a1cb1ec645cbc09"},
+    {file = "Shapely-1.8.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cec89a5617c0137f4678282e983c3d63bf838fb00cdf318cc555b4d8409f7130"},
+    {file = "Shapely-1.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:68c8e18dc9dc8a198c3addc8c9596f64137101f566f04b96ecfca0b214cb8b12"},
+    {file = "Shapely-1.8.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f12695662c3ad1e6031b3de98f191963d0f09de6d1a4988acd907405644032ba"},
+    {file = "Shapely-1.8.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:15a856fbb588ad5d042784e00918c662902776452008c771ecba2ff615cd197a"},
+    {file = "Shapely-1.8.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d74de394684d66e25e780b0359fda85be7766af85940fa2dfad728b1a815c71f"},
+    {file = "Shapely-1.8.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f3fac625690f01f35af665649e993f15f924e740b5c0ac0376900655815521"},
+    {file = "Shapely-1.8.2-cp38-cp38-win32.whl", hash = "sha256:1d95842cc6bbbeab673061b63e70b07be9a375c15a60f4098f8fbd29f43af1b4"},
+    {file = "Shapely-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:a58e1f362f2091743e5e13212f5d5d16251a4bb63dd0ed587c652d3be9620d3a"},
+    {file = "Shapely-1.8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5254240eefc44139ab0d128faf671635d8bdd9c23955ee063d4d6b8f20073ae0"},
+    {file = "Shapely-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75042e8039c79dd01f102bb288beace9dc2f49fc44a2dea875f9b697aa8cd30d"},
+    {file = "Shapely-1.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0c0fd457ce477b1dced507a72f1e2084c9191bfcb8a1e09886990ebd02acf024"},
+    {file = "Shapely-1.8.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6fcb28836ae93809de1dde73c03c9c24bab0ba2b2bf419ddb2aeb72c96d110e9"},
+    {file = "Shapely-1.8.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:44d2832c1b706bf43101fda92831a083467cc4b4923a7ed17319ab599c1025d8"},
+    {file = "Shapely-1.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:137f1369630408024a62ff79a437a5657e6c5b76b9cd352dde704b425acdb298"},
+    {file = "Shapely-1.8.2-cp39-cp39-win32.whl", hash = "sha256:2e02da2e988e74d61f15c720f9f613fab51942aae2dfeacdcb78eadece00e1f3"},
+    {file = "Shapely-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:3423299254deec075e79fb7dc7909d702104e4167149de7f45510c3a6342eeea"},
+    {file = "Shapely-1.8.2.tar.gz", hash = "sha256:572af9d5006fd5e3213e37ee548912b0341fb26724d6dc8a4e3950c10197ebb6"},
 ]
 "simplejson 3.17.6" = [
     {file = "simplejson-3.17.6-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a89acae02b2975b1f8e4974cb8cdf9bf9f6c91162fb8dec50c259ce700f2770a"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -357,7 +357,7 @@ summary = "Tiny 'shelve'-like database with concurrency support"
 [[package]]
 name = "pillow"
 version = "8.4.0"
-requires_python = ">=3.7"
+requires_python = ">=3.6"
 summary = "Python Imaging Library (Fork)"
 
 [[package]]
@@ -403,6 +403,15 @@ name = "pycparser"
 version = "2.21"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 summary = "C parser in Python"
+
+[[package]]
+name = "pygeos"
+version = "0.12.0"
+requires_python = ">=3.6"
+summary = "GEOS wrapped in numpy ufuncs"
+dependencies = [
+    "numpy>=1.13",
+]
 
 [[package]]
 name = "pygments"
@@ -776,7 +785,7 @@ dependencies = [
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:44d0c7f46bd297ba2b244347afff9f9c2e696c35ecacc9ca43ef19a94fb5b363"
+content_hash = "sha256:d7040c9a2e2e3468291b10aca136372a5e0f742638d4523cc13c2d37522cff3c"
 
 [metadata.files]
 "aiohttp 3.8.1" = [
@@ -1384,6 +1393,42 @@ content_hash = "sha256:44d0c7f46bd297ba2b244347afff9f9c2e696c35ecacc9ca43ef19a94
 "pycparser 2.21" = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+"pygeos 0.12.0" = [
+    {file = "pygeos-0.12.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e3593360f1a93d2a6fe1ea75fa84882186bd3851d187e4c4bbb586495c748e3d"},
+    {file = "pygeos-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec4112b69823866fa966ec4869e1b51b6560d892c65c20b3fb065266519046e2"},
+    {file = "pygeos-0.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75b5b0aefffb6b7747df299414df4f2e160e3a8993d2b6a86b805fb5b0196f13"},
+    {file = "pygeos-0.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26fae3eabb83a15348c2c3f78892114aca9bc4efaa342ab2fa3fa39a85e05dc5"},
+    {file = "pygeos-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:b4ec8fe577ca7ba6dd046481cdb736f99961216fcb54c84211287a10d1158459"},
+    {file = "pygeos-0.12.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6db68dc4583c88222d32cc624622234a97080b3c4650f0c0e12987664d49f374"},
+    {file = "pygeos-0.12.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da856315a4047d581300d860dd2aa01438e64121570bed46c81ad0a90f477db0"},
+    {file = "pygeos-0.12.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3cf6d734aea07f04c7644ae24e303a447e96ea123ea524ab309e492ca683240e"},
+    {file = "pygeos-0.12.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12e06ec4417453f1a95d36b8ba8822569c30f6938dd4a7bac97433cab641b61f"},
+    {file = "pygeos-0.12.0-cp36-cp36m-win32.whl", hash = "sha256:ea7f3ea9c76f8c94ed9b360b4d6249c44d5bc48c8db5cb3a5d4b017e51d1bd8a"},
+    {file = "pygeos-0.12.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6cf496887f25b99427624399bcd07107660e6f9135466c33dc60ad9bd4c9ebe"},
+    {file = "pygeos-0.12.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f155f268676ff7b20a553a542a436be0f8df14233c873facc80214d836d6463b"},
+    {file = "pygeos-0.12.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74abd81487839532c7110721f3b1450d0c6bcfb5e18c45d604ddeb75ec99f86"},
+    {file = "pygeos-0.12.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac4ddfbe548d8a3e93732577b8a6d4df071f038338f6c400466b3c2bfe3dc78"},
+    {file = "pygeos-0.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:504a03330147d2bb3309f291f4333db892cdba40a66ac4f3db8a2672dff7cf4f"},
+    {file = "pygeos-0.12.0-cp37-cp37m-win32.whl", hash = "sha256:e3bcfb55e966aea26ff8e9b8fd314cee618c363f639e83b1eaaefb66bc97e7b0"},
+    {file = "pygeos-0.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:835b7b1b2ef44453ff9d759dd67ee17fb89a52d8cdbd4d1655bf0be6ccfd90c3"},
+    {file = "pygeos-0.12.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:60d103b4c099940ad73f0b193f65dfc77f957646451b8a399e4f1f5835c57ab6"},
+    {file = "pygeos-0.12.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5bc1b9a548848f9c69c913eca8ab0bb9164b35a28da51f86fcc0887c553bd863"},
+    {file = "pygeos-0.12.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:11cb186f6cb9a2453a990a3e9894f861d308c574170d1c6f55a598cb11b87579"},
+    {file = "pygeos-0.12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8fcb175645f57d7a6fa153a1582f9dbf625bb69c55267207b1bc8d2b983013b"},
+    {file = "pygeos-0.12.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2453c07c9b8a24054f897ed56e8046c7dd743939f7f5d6637fdeafdccc411f29"},
+    {file = "pygeos-0.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962df97f937d6656ce9293e7072318e99860b0d41f61df9017551855a8bc188e"},
+    {file = "pygeos-0.12.0-cp38-cp38-win32.whl", hash = "sha256:d72e3691e47f44b49d3a23f05bb55eca34ed28b0e7b1b4aeb50207a95ae83f8f"},
+    {file = "pygeos-0.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:41119e394ea90bf8f697613f530cf92c77ab98346c19cb19beba33a82fd5b91d"},
+    {file = "pygeos-0.12.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:dfad4c0a4b60861f8e571ca409ce128859d26e1ac26a15ee071cf1f222431fdd"},
+    {file = "pygeos-0.12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:aeaf1f9ae45cf35a25ccdeb2b083e057b31d98cf9351bfc42a59352130ff5c31"},
+    {file = "pygeos-0.12.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:59971b44e3b8f61e96b159acdc5f9347b94766a4efb94af7b926b1c4958b60d4"},
+    {file = "pygeos-0.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efcbd52e5602d758b1ff42e67b91b33b1599667b478d0be9c13e17b286cbfcf0"},
+    {file = "pygeos-0.12.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47e7b2614d8982f841e33cc1f18d39b7a654d4d7958d456e4765ff4a9c76589b"},
+    {file = "pygeos-0.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f045632a940905c2f380544450bbcd48556b529bdfb9320aac777d90990fc25"},
+    {file = "pygeos-0.12.0-cp39-cp39-win32.whl", hash = "sha256:d2fefb3a9cf96d1ee4841772464e82b2ae3a8ddf3caf14ecb04c5fcdae6a7248"},
+    {file = "pygeos-0.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:25b94e8bc755a8d3e50661995556b2c27d253bfdd55aa719ea3c202de44a9569"},
+    {file = "pygeos-0.12.0.tar.gz", hash = "sha256:3c41542ef67c66015f443ae3e6e683503a8a221f9c24fb2380f6ae42aed1600a"},
 ]
 "pygments 2.10.0" = [
     {file = "Pygments-2.10.0-py3-none-any.whl", hash = "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "aiohttp>=3.8.1",
     "gunicorn>=20.1.0",
     "sentry-sdk>=1.5.12",
+    "shapely>=1.8.2",
 ]
 requires-python = ">=3.10,<4.0"
 license = {text = "AGPLv3"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "gunicorn>=20.1.0",
     "sentry-sdk>=1.5.12",
     "shapely>=1.8.2",
+    "pygeos>=0.12.0",
 ]
 requires-python = ">=3.10,<4.0"
 license = {text = "AGPLv3"}

--- a/server/app.py
+++ b/server/app.py
@@ -25,7 +25,9 @@ async def webapp():
             web.get("/", entry),
             web.get("/api/getFeature", getFeature),
             web.get("/api/getData", getData),
+            web.post("/api/getData", getData),
             web.get("/api/getStats", getStats),
+            web.post("/api/getStats", getStats),
             web.get("/tiles/{z}/{x}/{y}.png", tile),
         ]
     )

--- a/server/process.py
+++ b/server/process.py
@@ -17,6 +17,8 @@ def generate_raw(multipolygon, start, end, *filters, **headers):
         bbox = mercantile.Bbox(*multipolygon.bounds)
         fast_comparison = multipolygon == shapely.geometry.box(*bbox)
         for tile in bbox_tiles(bbox, Z_TARGET):
+            tile_box = shapely.geometry.box(*mercantile.bounds(*tile))
+            sliced = multipolygon.intersection(tile_box)
             quadkey = mercantile.quadkey(tile)
             for feature in get_tile_data(
                 quadkey, start, end, *filters, **headers
@@ -25,7 +27,7 @@ def generate_raw(multipolygon, start, end, *filters, **headers):
                     if lonlat_in_bbox(bbox, feature[0], feature[1]):
                         yield feature
                 else:
-                    if shape_contains_feature(multipolygon, feature):
+                    if shape_contains_feature(sliced, feature):
                         yield feature
 
 

--- a/server/process.py
+++ b/server/process.py
@@ -15,10 +15,10 @@ from .utils import get_updated_metadata, lonlat_in_bbox, shape_contains_feature
 def generate_raw(multipolygon, start, end, *filters, **headers):
     if not multipolygon.is_empty:
         bbox = mercantile.Bbox(*multipolygon.bounds)
-        fast_comparison = multipolygon == shapely.geometry.box(*bbox)
         for tile in bbox_tiles(bbox, Z_TARGET):
             tile_box = shapely.geometry.box(*mercantile.bounds(*tile))
             sliced = multipolygon.intersection(tile_box)
+            fast_comparison = sliced.bounds == tile_box.bounds
             quadkey = mercantile.quadkey(tile)
             for feature in get_tile_data(
                 quadkey, start, end, *filters, **headers

--- a/server/process.py
+++ b/server/process.py
@@ -18,6 +18,8 @@ def generate_raw(multipolygon, start, end, *filters, **headers):
         for tile in bbox_tiles(bbox, Z_TARGET):
             tile_box = shapely.geometry.box(*mercantile.bounds(*tile))
             sliced = multipolygon.intersection(tile_box)
+            if sliced.is_empty:
+                continue
             fast_comparison = sliced.bounds == tile_box.bounds
             quadkey = mercantile.quadkey(tile)
             for feature in get_tile_data(

--- a/server/statistics.py
+++ b/server/statistics.py
@@ -40,6 +40,7 @@ async def getStats(request):
     stats = collections.defaultdict(collections.OrderedDict)
     for param in params:
         values_p = values[param]
+        stats[param]["nodes"] = len(values[param])
         if len(values_p) >= 1:
             stats[param] |= {
                 "min": min(values_p),

--- a/server/tile.py
+++ b/server/tile.py
@@ -4,7 +4,6 @@ import math
 import statistics
 
 import mercantile
-import PIL
 import png
 from aiohttp import web
 
@@ -33,7 +32,6 @@ async def tile(request):
     scale_max = request.rel_url.query.get("scale_max")
     percentile = int(request.rel_url.query.get("percentile", "50"))
     resolution = int(request.rel_url.query.get("resolution", "8"))
-    upscale = int(request.rel_url.query.get("upscale", resolution))
     if percentile < 0 or percentile > 100 or z < 11:
         return web.Response(
             body=generate_invalid_tile(), content_type="image/png"
@@ -120,13 +118,6 @@ async def tile(request):
     writer = png.Writer(resolution, resolution, greyscale=False)
     writer.write_array(tile, colors)
     tile.seek(0)
-
-    if upscale > resolution:
-        image = PIL.Image.open(tile)
-        scaled = image.resize((upscale, upscale), resample=PIL.Image.BOX)
-        tile = io.BytesIO()
-        scaled.save(tile, "png")
-        tile.seek(0)
 
     return web.Response(body=tile.getvalue(), content_type="image/png")
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -68,7 +68,6 @@ async def request_to_multipolygon(request):
     post = await request.post()
     geojson = post.get("geojson")
     if geojson:
-        print(type(geojson), flush=True)
         if isinstance(geojson, aiohttp.web_request.FileField):
             geojson = geojson.file.read()
         geometry = pygeos.from_geojson(geojson)

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,7 +1,9 @@
 import urllib.parse
 import urllib.request
 
+import aiohttp.web_request
 import mercantile
+import pygeos
 import shapely.geometry
 import simplejson as json
 
@@ -64,13 +66,13 @@ async def request_to_multipolygon(request):
 
     # geojson
     post = await request.post()
-    geojson_text = post.get("geojson")
-    if geojson_text:
-        geojson = json.loads(geojson_text)
-        for feature in geojson["features"]:
-            geometry = shapely.geometry.shape(feature["geometry"])
-            if geometry.type == "Polygon":
-                multipolygon = multipolygon.union(geometry)
+    geojson = post.get("geojson")
+    if geojson:
+        print(type(geojson), flush=True)
+        if isinstance(geojson, aiohttp.web_request.FileField):
+            geojson = geojson.file.read()
+        geometry = pygeos.from_geojson(geojson)
+        multipolygon = pygeos.to_shapely(geometry)
 
     # tile or bbox
     bbox_polygon = shapely.geometry.Polygon()

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-bullseye AS apt
 LABEL maintainer="fraph24@gmail.com"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-WORKDIR /home/app
+WORKDIR /app
 
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get -qy install firefox-esr xvfb

--- a/web/src/bar.js
+++ b/web/src/bar.js
@@ -35,6 +35,8 @@ function AccordionItem({ title, children }) {
 
 function Bar({
   setFilter,
+  customBoundaries,
+  setCustomBoundaries,
   mode,
   setMode,
   percentile,
@@ -46,7 +48,10 @@ function Bar({
   return (
     <div id="bar" className={classNames(className, 'bg-light', 'accordion')}>
       <AccordionItem title="Filters">
-        <Settings setFilter={setFilter} />
+        <Settings
+          setFilter={setFilter}
+          setCustomBoundaries={setCustomBoundaries}
+        />
       </AccordionItem>
       <AccordionItem title="Criteria">
         <Criteria
@@ -60,7 +65,7 @@ function Bar({
         <Statistics mode={mode} statistics={statistics} />
       </AccordionItem>
       <AccordionItem title="Save">
-        <Download query={query} />
+        <Download query={query} customBoundaries={customBoundaries} />
       </AccordionItem>
     </div>
   );

--- a/web/src/components/download.js
+++ b/web/src/components/download.js
@@ -2,11 +2,47 @@ import React from 'react';
 
 const classNames = require('classnames');
 
-function Download({ query }) {
+function Download({ query, customBoundaries }) {
   const urlData = `/api/getData?${query}`;
   const urlStats = `/api/getStats?${query}`;
+  if (customBoundaries) {
+    return (
+      <>
+        <p>Only nodes within the GeoJSON areas are considered.</p>
+        <form action={urlData} method="POST" className="d-inline">
+          <input
+            type="text"
+            name="geojson"
+            value={JSON.stringify(customBoundaries)}
+            readOnly
+            className="d-none"
+          />
+          <button className="btn btn-primary" type="submit">
+            <i className="fas fa-arrow-alt-circle-down" />
+            &nbsp;
+            <span>GeoJSON data</span>
+          </button>
+        </form>
+        <form action={urlStats} method="POST" className="d-inline">
+          <input
+            type="text"
+            name="geojson"
+            value={JSON.stringify(customBoundaries)}
+            readOnly
+            className="d-none"
+          />
+          <button className="btn btn-secondary" type="submit">
+            <i className="fas fa-arrow-alt-circle-down" />
+            &nbsp;
+            <span>Statistics</span>
+          </button>
+        </form>
+      </>
+    );
+  }
   return (
     <>
+      <p>Only nodes within the current view are considered.</p>
       <a
         className={classNames('btn', 'btn-primary', {
           disabled: !query,

--- a/web/src/components/settings.js
+++ b/web/src/components/settings.js
@@ -1,23 +1,72 @@
 import React, { useState } from 'react';
 
-function Settings({ setFilter }) {
+const classNames = require('classnames');
+
+function Settings({ setFilter, setCustomBoundaries }) {
   const [text, setText] = useState('');
+  const [fileUploaded, setFileUploaded] = useState(false);
 
   function handleSubmit(e) {
     e.preventDefault();
     setFilter(text);
   }
 
+  function uploadFile(e) {
+    setFileUploaded(true);
+    e.target.files[0]
+      .text()
+      .then((geojson) => {
+        setCustomBoundaries(JSON.parse(geojson));
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-alert
+        alert(`Please select a valid GeoJSON file. Error: ${error}`);
+      });
+  }
+
+  function removeFile() {
+    const boundariesForm = document.getElementById('boundariesForm');
+    boundariesForm.reset();
+    setCustomBoundaries();
+    setFileUploaded(false);
+  }
+
   return (
-    <form className="input-group" onSubmit={handleSubmit}>
-      <input
-        className="form-control"
-        type="text"
-        placeholder="example: amenity=*"
-        onChange={(event) => setText(event.target.value.trim())}
-      />
-      <input className="btn btn-primary" type="submit" value="Set" />
-    </form>
+    <>
+      <form className="input-group" onSubmit={handleSubmit}>
+        <input
+          className="form-control"
+          type="text"
+          placeholder="example: amenity=*"
+          onChange={(event) => setText(event.target.value.trim())}
+        />
+        <input className="btn btn-primary" type="submit" value="Set" />
+      </form>
+      <br />
+      <form
+        id="boundariesForm"
+        className="input-group"
+        onSubmit={(e) => e.preventDefault()}
+      >
+        <label htmlFor="boundaries">Upload custom boundaries (GeoJSON)</label>
+        <input
+          className="form-control"
+          type="file"
+          id="boundaries"
+          name="boundaries"
+          onChange={uploadFile}
+        />
+        <button
+          type="button"
+          className={classNames('btn', 'btn-secondary', {
+            disabled: !fileUploaded,
+          })}
+          onClick={removeFile}
+        >
+          <i className="fa fa-trash" />
+        </button>
+      </form>
+    </>
   );
 }
 

--- a/web/src/components/statistics.js
+++ b/web/src/components/statistics.js
@@ -11,7 +11,11 @@ function Statistics({ mode, statistics }) {
           Object.keys(statistics[mode]).map((key) => (
             <tr key={key}>
               <th scope="row">{key}</th>
-              <td>{modes[mode].prettyValue(statistics[mode][key])}</td>
+              <td>
+                {key === 'nodes'
+                  ? statistics[mode][key]
+                  : modes[mode].prettyValue(statistics[mode][key])}
+              </td>
             </tr>
           ))}
       </tbody>

--- a/web/src/constants.js
+++ b/web/src/constants.js
@@ -1,5 +1,5 @@
 export const maxZoom = 19;
-export const minZoom = 13;
+export const minZoom = 12;
 export const zoomLevelSwitch = 16;
 export const defaultLocation = [17, 45.46423, 9.19073];
 

--- a/web/src/constants.js
+++ b/web/src/constants.js
@@ -1,5 +1,6 @@
 export const maxZoom = 19;
 export const minZoom = 13;
+export const zoomLevelSwitch = 16;
 export const defaultLocation = [17, 45.46423, 9.19073];
 
 export const customAttribution = `<a href="https://github.com/frafra/is-osm-uptodate">${document.title}</a> | <a href="https://api.ohsome.org/">ohsome API</a> | &copy; <a href="https://ohsome.org/copyrights">OpenStreetMap contributors</a>`;

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -22,7 +22,7 @@ if (SENTRY_DSN) {
 }
 
 function App() {
-  const [loadingStats, setLoadingStats] = useState(false);
+  const [loadingStats, setLoadingStats] = useState(0);
   const [bounds, setBounds] = useState();
   const [filter, setFilter] = useState('');
   const [mode, setMode] = useState('lastedit');
@@ -46,7 +46,7 @@ function App() {
 
   useEffect(() => {
     if (!query) return;
-    setLoadingStats(true);
+    setLoadingStats((counter) => counter + 1);
     fetch(`/api/getStats?${query}`)
       .then((response) => {
         if (response.ok) {
@@ -57,11 +57,11 @@ function App() {
         });
       })
       .then((parsed) => {
-        setLoadingStats(false);
+        setLoadingStats((counter) => counter - 1);
         setStatistics(parsed);
       })
       .catch((error) => {
-        setLoadingStats(false);
+        setLoadingStats((counter) => counter - 1);
         throw new Error(error);
       });
   }, [query]);

--- a/web/src/map.js
+++ b/web/src/map.js
@@ -445,7 +445,16 @@ function Map({
       />
       <GetBounds setBounds={setBounds} />
 
-      {customBoundaries && <GeoJSON data={customBoundaries} />}
+      {customBoundaries && (
+        <GeoJSON
+          data={customBoundaries}
+          style={{
+            color: 'black',
+            fill: false,
+            dashArray: '10',
+          }}
+        />
+      )}
       {loadAllData ? (
         <MarkerClusterGroup
           ref={clusterRef}


### PR DESCRIPTION
Fix #4.

Users can send a GeoJSON with one or more polygons to set custom boundaries, using `shapely` and `pygeos`.
Some useless reloads have been removed too.

Turin (http://polygons.openstreetmap.fr/?id=44875) requires ~50s on my local PC (154299 nodes loaded), when the data is already cached. The intersection operation is executed on a single thread.
Milan (http://polygons.openstreetmap.fr/?id=44915) requires ~1m 50s (146074 nodes loaded) on the same setup.

**Update:** I was able to get a ~20 times improvement with a couple of optimizations (like slicing the polygon using the tiles as grid or using a simpler function when the sliced polygon matches with the bounding box of a tile).